### PR TITLE
Add automatic build based on dcist-master docker image

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,40 @@
+name: docker-build-base
+
+# Only build base when any of the files in the base directory are modified
+on:
+  push:
+    branches: [master, ci]
+    tags:
+      - '*'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+
+    steps:
+      -
+        name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}"
+          push: false
+          platforms: linux/amd64
+          build-args: git_hash=${{ github.sha }}
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,9 +1,9 @@
-name: docker-build-base
+name: docker-build-CI
 
 # Only build base when any of the files in the base directory are modified
 on:
   push:
-    branches: [master, ci]
+    branches: [main, ci]
     tags:
       - '*'
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Note: this Dockerfile is only used for the CI. Please refer to the
+# instructions in README.md to use this repo
+
+FROM kumarrobotics/dcist-master:latest
+
+# Requires a docker build argument `user_id`
+ARG user_id=1000
+env USER dcist
+
+# Create a base docker environment
+RUN . /home/$USER/dcist_ws/devel/setup.sh \
+ && mkdir -p /home/$USER/user_ws/src && cd /home/$USER/user_ws \
+ && catkin config --extend ~/dcist_ws/devel \
+ && catkin build --no-status -DCMAKE_BUILD_TYPE=Release
+
+# Copy the spomp environment into the user workspace
+COPY --chown=$USER:$USER . /home/$USER/user_ws/src/spomp-system
+
+# Build the workspace
+RUN cd /home/$USER/user_ws \
+ && catkin build --no-status -DCMAKE_BUILD_TYPE=Release \
+ && catkin build

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ Here are all the submodules needed for the stack.
 
 [<img src="video_thumbnail.png">](https://www.youtube.com/watch?v=jcPOVRsdUhU)
 
+## How to run the code?
+We provide Docker images that can be used to run this code:
+```
+# Clone and run the master docker image
+git clone https://github.com/KumarRobotics/dcist_master.git
+cd dcist_master
+./run.bash dcist-master
+
+# Clone the repo and build
+cd user_ws
+mkdir src
+git clone --recursive -j8 https://github.com/KumarRobotics/spomp-system.git src/spomp-system
+catkin config --extend ~/dcist_ws/devel && catkin build -DCMAKE_BUILD_TYPE=Release
+```
+
+Launch files for air and ground robots can be found inside `semantics_manager`.
+
 ## Main modules
 
 - [semantics_manager](http://github.com/KumarRobotics/semantics_manager): Starting point for launch files and configuration management

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SPOMP: Semantic Panoramic Online Mapping and Planning
+![Docker CI Build](https://github.com/KumarRobotics/spomp-system/actions/workflows/docker-build.yaml/badge.svg?branch=main)
 
 This is the public code repository for our work SPOMP.
 Here are all the submodules needed for the stack.


### PR DESCRIPTION
This PR adds a build CI based on `dcist-master` docker image. It just builds the ROS repo and it does not generate an output image. 